### PR TITLE
Derive some traits

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -18,7 +18,7 @@ use std::str::FromStr;
 use crate::Error;
 
 /// Arbitrary arguments and parameters.
-#[derive(Clone, Serialize)]
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
 #[serde(transparent)]
 #[serde_as]
 pub struct Args {
@@ -64,7 +64,7 @@ impl Args {
     pub fn iter_mut(&mut self) -> std::collections::hash_map::IterMut<'_, String, String> {
         self.map.iter_mut()
     }
-    /// Get a reference to the underlying [HashMap](std::collections::HashMap).
+    /// Get a reference to the underlying [HashMap](HashMap).
     pub fn map(&self) -> &HashMap<String, String> {
         &self.map
     }

--- a/src/args.rs
+++ b/src/args.rs
@@ -64,7 +64,7 @@ impl Args {
     pub fn iter_mut(&mut self) -> std::collections::hash_map::IterMut<'_, String, String> {
         self.map.iter_mut()
     }
-    /// Get a reference to the underlying [HashMap](HashMap).
+    /// Get a reference to the underlying [HashMap](std::collections::HashMap).
     pub fn map(&self) -> &HashMap<String, String> {
         &self.map
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,8 @@ mod streamer;
 pub use streamer::RxStreamer;
 pub use streamer::TxStreamer;
 
+use serde::{Deserialize, Serialize};
+
 #[cfg(all(feature = "web", not(target_arch = "wasm32")))]
 pub(crate) mod web;
 #[cfg(all(feature = "web", not(target_arch = "wasm32")))]
@@ -31,7 +33,7 @@ use std::str::FromStr;
 use thiserror::Error;
 
 /// Seify Error
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, Clone, Error, PartialEq, Serialize, Deserialize)]
 pub enum Error {
     #[error("DeviceError")]
     DeviceError,
@@ -58,7 +60,7 @@ impl From<std::io::Error> for Error {
 }
 
 /// Supported hardware drivers.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum Driver {
     Aaronia,
@@ -89,7 +91,7 @@ impl FromStr for Driver {
 }
 
 /// Direction (Rx/TX)
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub enum Direction {
     Rx,
     Tx,

--- a/src/range.rs
+++ b/src/range.rs
@@ -13,7 +13,7 @@ pub enum RangeItem {
 }
 
 /// Range of possible values, comprised of individual values and/or intervals.
-#[derive(Debug, Clone, Serialize, Deserialize)] //Serialize might be risky due to large memory allocations with Soapy
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Range {
     items: Vec<RangeItem>,
 }

--- a/src/range.rs
+++ b/src/range.rs
@@ -1,7 +1,10 @@
+use serde::Deserialize;
+use serde::Serialize;
+
 /// Component of a [Range].
 ///
 /// Can be an interval or an individual value.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum RangeItem {
     /// Interval (inclusive).
     Interval(f64, f64),
@@ -10,7 +13,7 @@ pub enum RangeItem {
 }
 
 /// Range of possible values, comprised of individual values and/or intervals.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)] //Serialize might be risky due to large memory allocations with Soapy
 pub struct Range {
     items: Vec<RangeItem>,
 }


### PR DESCRIPTION
It would be nice, if for Seify's types, traits like (Debug, Clone, PartialEq , Serialize, Deserialize) could be derived or implemented, where derivation is not possible.