### PR TITLE
aaronia http request queueing, non-burst-mode, set agc

### DIFF
--- a/src/impls/aaronia_http.rs
+++ b/src/impls/aaronia_http.rs
@@ -672,16 +672,16 @@ impl crate::TxStreamer for TxStreamer {
             )
         };
 
-        log::debug!(
-            "sending {}{} samples with delay of {}s",
-            if end_burst { "burst of " } else { "" },
-            num_streamable_samples,
-            start
-                - SystemTime::now()
-                    .duration_since(SystemTime::UNIX_EPOCH)
-                    .unwrap()
-                    .as_secs_f64()
-        );
+        // log::debug!(
+        //     "sending {}{} samples with delay of {}s",
+        //     if end_burst { "burst of " } else { "" },
+        //     num_streamable_samples,
+        //     start
+        //         - SystemTime::now()
+        //             .duration_since(SystemTime::UNIX_EPOCH)
+        //             .unwrap()
+        //             .as_secs_f64()
+        // );
 
         let j = json!({
             "startTime": start,


### PR DESCRIPTION
- queue tx requests, else the device will drop overlapping requests (based on requested tx start time)
- add support for non-burst transmissions (including partial transmission if queue is filling up, 1 second queueing limit)
- add support for setting agc
- reduce tx streaming delay from 0.8s to 0.01s (suitable for device on same host, probably also in local network, but might need to be increased again for remote access based on latency)