### PR TITLE
Fix a typo in the `suports_agc()` function, and expose the `items` field of the `Range` struct

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -50,7 +50,7 @@ pub trait DeviceTrait: Any + Send {
 
     //================================ AGC ============================================
     /// Does the device support automatic gain control?
-    fn suports_agc(&self, direction: Direction, channel: usize) -> Result<bool, Error>;
+    fn supports_agc(&self, direction: Direction, channel: usize) -> Result<bool, Error>;
 
     /// Enable or disable automatic gain control.
     fn enable_agc(&self, direction: Direction, channel: usize, agc: bool) -> Result<(), Error>;
@@ -520,8 +520,8 @@ impl<
         self.dev.gain_elements(direction, channel)
     }
 
-    fn suports_agc(&self, direction: Direction, channel: usize) -> Result<bool, Error> {
-        self.dev.suports_agc(direction, channel)
+    fn supports_agc(&self, direction: Direction, channel: usize) -> Result<bool, Error> {
+        self.dev.supports_agc(direction, channel)
     }
 
     fn enable_agc(&self, direction: Direction, channel: usize, agc: bool) -> Result<(), Error> {
@@ -698,8 +698,8 @@ impl DeviceTrait for GenericDevice {
         self.as_ref().gain_elements(direction, channel)
     }
 
-    fn suports_agc(&self, direction: Direction, channel: usize) -> Result<bool, Error> {
-        self.as_ref().suports_agc(direction, channel)
+    fn supports_agc(&self, direction: Direction, channel: usize) -> Result<bool, Error> {
+        self.as_ref().supports_agc(direction, channel)
     }
 
     fn enable_agc(&self, direction: Direction, channel: usize, agc: bool) -> Result<(), Error> {
@@ -892,8 +892,8 @@ impl<
 
     //================================ AGC ============================================
     /// Does the device support automatic gain control?
-    pub fn suports_agc(&self, direction: Direction, channel: usize) -> Result<bool, Error> {
-        self.dev.suports_agc(direction, channel)
+    pub fn supports_agc(&self, direction: Direction, channel: usize) -> Result<bool, Error> {
+        self.dev.supports_agc(direction, channel)
     }
     /// Enable or disable automatic gain control.
     pub fn enable_agc(&self, direction: Direction, channel: usize, agc: bool) -> Result<(), Error> {

--- a/src/impls/aaronia.rs
+++ b/src/impls/aaronia.rs
@@ -203,7 +203,7 @@ impl DeviceTrait for Aaronia {
         }
     }
 
-    fn suports_agc(&self, direction: Direction, channel: usize) -> Result<bool, Error> {
+    fn supports_agc(&self, direction: Direction, channel: usize) -> Result<bool, Error> {
         match (direction, channel) {
             (Rx, 0 | 1) => Ok(true),
             _ => Err(Error::ValueError),

--- a/src/impls/aaronia_http.rs
+++ b/src/impls/aaronia_http.rs
@@ -253,7 +253,7 @@ impl DeviceTrait for AaroniaHttp {
         }
     }
 
-    fn suports_agc(&self, direction: Direction, channel: usize) -> Result<bool, Error> {
+    fn supports_agc(&self, direction: Direction, channel: usize) -> Result<bool, Error> {
         match (direction, channel) {
             (Rx, 0 | 1) => Ok(true),
             _ => Err(Error::ValueError),

--- a/src/impls/rtlsdr.rs
+++ b/src/impls/rtlsdr.rs
@@ -171,7 +171,7 @@ impl DeviceTrait for RtlSdr {
         }
     }
 
-    fn suports_agc(&self, direction: Direction, channel: usize) -> Result<bool, Error> {
+    fn supports_agc(&self, direction: Direction, channel: usize) -> Result<bool, Error> {
         if matches!(direction, Rx) && channel == 0 {
             Ok(true)
         } else if matches!(direction, Rx) {

--- a/src/impls/soapy.rs
+++ b/src/impls/soapy.rs
@@ -139,7 +139,7 @@ impl DeviceTrait for Soapy {
         Ok(self.dev.list_gains(direction.into(), channel)?)
     }
 
-    fn suports_agc(&self, direction: Direction, channel: usize) -> Result<bool, Error> {
+    fn supports_agc(&self, direction: Direction, channel: usize) -> Result<bool, Error> {
         Ok(self.dev.has_gain_mode(direction.into(), channel)?)
     }
 

--- a/src/range.rs
+++ b/src/range.rs
@@ -17,7 +17,7 @@ pub enum RangeItem {
 /// Range of possible values, comprised of individual values and/or intervals.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Range {
-    items: Vec<RangeItem>,
+    pub items: Vec<RangeItem>,
 }
 
 impl Range {


### PR DESCRIPTION
This is a very simple PR. It's pretty much exactly what the name implies.

1. I exposed the inner `items` field in the `Range` struct. I found that the `Range` struct is pretty much useless otherwise. I was unable to get the minimum and maximum values of *sample rate* and *gain* ranges.
2. I found a typo in the `suports_agc()` function. That's an easy fix.

Eventually, I would like to see the `RangeItem` enum replaced. It's a little cumbersome, as I now have to do a pattern match to figure out what I'm dealing with. I feel like there's a more elegant way to implement it.

Thanks for creating seify! I am hopeful that this will replace SoapySDR in the future. SoapySDR is awesome, but the drivers constantly cause my program to crash from random bugs. If there is anything I can do to help, don't hesitate to let me know!