### PR TITLE
Fix conversion from soapysdr::Args into seify::Args

### DIFF
--- a/src/impls/soapy.rs
+++ b/src/impls/soapy.rs
@@ -413,6 +413,10 @@ impl TryFrom<soapysdr::Args> for Args {
     type Error = Error;
 
     fn try_from(value: soapysdr::Args) -> Result<Self, Self::Error> {
-        value.to_string().try_into()
+        let mut a = Self::new();
+        for (key, value) in value.iter() {
+            a.set(key, value);
+        }
+        Ok(a)
     }
 }


### PR DESCRIPTION
I noticed when enumerating devices through the soapy driver that certain args were missing or would get truncated to one word.

For example, with the soapysdr+rtlsdr driver, the 'label' field should be "Generic RTL2832U OEM :: 00000001", but it gets truncated to "Generic". Some other args were completely missing as well.

This just changes how the `soapysdr::Args` are cast into `seify::Args`