### PR TITLE
Added "once" call to `soapysdr::configure_logging()`

### DIFF
--- a/src/impls/soapy.rs
+++ b/src/impls/soapy.rs
@@ -1,5 +1,7 @@
 //! Soapy SDR
+
 use num_complex::Complex32;
+use std::sync::OnceLock;
 
 use crate::Args;
 use crate::DeviceTrait;
@@ -27,6 +29,16 @@ pub struct TxStreamer {
     streamer: soapysdr::TxStream<Complex32>,
 }
 
+/// Configures SoapySDR logging to route through the `log` crate.
+///
+/// This function is idempotent and will only configure logging once.
+fn init_soapy_logging() {
+    static INIT: OnceLock<()> = OnceLock::new();
+    INIT.get_or_init(|| {
+        soapysdr::configure_logging();
+    });
+}
+
 impl Soapy {
     /// Get a list of detected devices, supported by Soapy
     ///
@@ -34,6 +46,7 @@ impl Soapy {
     /// this particular device. Using the `soapy_driver` argument it is possible to specify the
     /// `driver` argument for Soapy.
     pub fn probe(args: &Args) -> Result<Vec<Args>, Error> {
+        init_soapy_logging();
         let v = soapysdr::enumerate(soapysdr::Args::try_from(args.clone())?)?;
         let v: Vec<Args> = v.into_iter().map(Into::into).collect();
         Ok(v.into_iter()
@@ -54,6 +67,7 @@ impl Soapy {
     /// It is possible to specify the Soapy `driver` argument by passing the `soapy_driver` argument
     /// to this function.
     pub fn open<A: TryInto<Args>>(args: A) -> Result<Self, Error> {
+        init_soapy_logging();
         let mut args: Args = args.try_into().or(Err(Error::ValueError))?;
         let index = args.get("index").unwrap_or(0);
 


### PR DESCRIPTION
Call establishes logging callback with SoapySDR API to route internal logging through the `log` crate.